### PR TITLE
Fix missing includes in controls component

### DIFF
--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -3,6 +3,7 @@
 
 #include <base/math.h>
 #include <base/vmath.h>
+#include <base/system.h>
 
 #include <algorithm> // std::clamp, std::max
 // #include <cmath> // (décommenter si besoin de std::sin/std::cos sur certaines toolchains)

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -4,6 +4,7 @@
 #define GAME_CLIENT_COMPONENTS_CONTROLS_H
 
 #include <base/vmath.h>
+#include <cstdint>
 
 #include <engine/client.h>
 #include <engine/console.h>
@@ -18,7 +19,7 @@ public:
 	float GetMinMouseDistance() const;
 	float GetMaxMouseDistance() const;
 
-	// Données publiques (héritées du client)
+	// DonnÃ©es publiques (hÃ©ritÃ©es du client)
 	vec2 m_aMousePos[NUM_DUMMIES];
 	vec2 m_aMousePosOnAction[NUM_DUMMIES];
 	vec2 m_aTargetPos[NUM_DUMMIES];
@@ -51,7 +52,7 @@ public:
 	void ResetInput(int Dummy);
 	bool CheckNewInput();
 
-	// === API ajoutée (features AvoidFreeze / HookAssist) ===
+	// === API ajoutÃ©e (features AvoidFreeze / HookAssist) ===
 	void AvoidFreeze();
 	void HookAssist();
 
@@ -62,7 +63,7 @@ private:
 	static void ConKeyInputSet(IConsole::IResult *pResult, void *pUserData);
 	static void ConKeyInputNextPrevWeapon(IConsole::IResult *pResult, void *pUserData);
 
-	// === États statiques (cooldowns) ===
+	// === Ã‰tats statiques (cooldowns) ===
 	static int64_t s_LastAvoidTime;
 	static int64_t s_LastActiveCheckTime;
 	static const int64_t ACTIVE_COOLDOWN;


### PR DESCRIPTION
## Summary
- include `<cstdint>` in the controls component header so MSVC sees the `int64_t` declarations
- include `<base/system.h>` in the controls implementation to provide `mem_zero`/`mem_copy` declarations on Windows

## Testing
- not run (cmake configuration fails because `glslangValidator` from the Vulkan SDK is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d97d36911c832ca28a01fd689fda2d